### PR TITLE
Fix: Comment the toast

### DIFF
--- a/src/context/checkout.tsx
+++ b/src/context/checkout.tsx
@@ -241,7 +241,7 @@ export const CheckoutProvider = (props: {
 
   useEffect(() => {
     if (checkoutError) {
-      toast.error(checkoutError.message)
+      // toast.error(checkoutError.message)
       setFieldValue('isValidCard', false)
       setFieldValue('token', '')
       setFieldValue('cardBrand', '')


### PR DESCRIPTION
This is done as a temporary measure to not show an error state when completing a payment.

**Current Behavior** 

Right after the payment is completed the widget show a graphql error, but when you refresh the widget it shoes success